### PR TITLE
20250912 fsaad parameters

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -1,0 +1,37 @@
+# https://github.com/marketplace/actions/run-julia-package-tests
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+  workflow_dispatch:
+
+# Needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+
+jobs:
+  Test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1.8']
+        julia-arch: [x64]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          annotate: true

--- a/Project.toml
+++ b/Project.toml
@@ -29,3 +29,9 @@ Match = "1.2.0"
 Parameters = "0.12.3"
 Statistics = "1"
 julia = "1.8"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,10 +50,10 @@ makedocs(
 deploydocs(
     repo="github.com/probsys/AutoGP.jl.git",
     push_preview=true,
-    # versions = [
-    #     "stable" => "v^",
-    #     "v#.#",
-    #     "v#.#.#",
-    #     "dev" => "dev",
-    #     ],
+    versions = [
+        "stable" => "v^",
+        "v#.#",
+        "v#.#.#",
+        "dev" => "dev",
+        ],
     )

--- a/docs/src/gp.md
+++ b/docs/src/gp.md
@@ -35,6 +35,7 @@ AutoGP.GP.eval_cov
 AutoGP.GP.compute_cov_matrix
 AutoGP.GP.compute_cov_matrix_vectorized
 AutoGP.GP.reparameterize
+AutoGP.GP.rescale
 ```
 
 ## [Primitive Kernels](@id gp_cov_kernel_prim)

--- a/docs/src/gp.md
+++ b/docs/src/gp.md
@@ -34,6 +34,7 @@ AutoGP.GP.size
 AutoGP.GP.eval_cov
 AutoGP.GP.compute_cov_matrix
 AutoGP.GP.compute_cov_matrix_vectorized
+AutoGP.GP.reparameterize
 ```
 
 ## [Primitive Kernels](@id gp_cov_kernel_prim)

--- a/src/GP.jl
+++ b/src/GP.jl
@@ -72,10 +72,10 @@ function reparameterize end
 
 Rescale the covariance kernel according to the given
 [`LinearTransform`](@ref) applied to the output.
-In particular, for a GP ``X ~ GP(0, k(\\cdot,\\cdot; \\theta))`` and a
+In particular, for a GP ``X \\sim \\mathrm{GP}(0, k(\\cdot,\\cdot; \\theta))`` and a
 transformation ``Y = aX + b``, this function
 returns a kernel with new parameters ``\\theta'``
-such that ``Y ~ GP(b, k(\\cdot,\\cdot; \\theta'))``.
+such that ``Y \\sim \\mathrm{GP}(b, k(\\cdot,\\cdot; \\theta'))``.
 """
 function rescale end
 

--- a/src/GP.jl
+++ b/src/GP.jl
@@ -568,11 +568,12 @@ function Distributions.MvNormal(
         ts::Vector{Float64},
         xs::Vector{Float64},
         ts_pred::Vector{Float64};
-        noise_pred::Union{Nothing,Float64}=nothing)
+        noise_pred::Union{Nothing,Float64}=nothing,
+        mean::Function=t->0.)
     noise_pred = isnothing(noise_pred) ? noise : noise_pred
     n_prev = length(ts)
     n_new = length(ts_pred)
-    means = zeros(n_prev + n_new)
+    means = map(mean, vcat(ts, ts_pred))
     cov_matrix = compute_cov_matrix_vectorized(node, 0., vcat(ts, ts_pred))
     cov_matrix_11 = cov_matrix[1:n_prev, 1:n_prev] + (noise * LinearAlgebra.I)
     cov_matrix_22 = cov_matrix[n_prev+1:n_prev+n_new, n_prev+1:n_prev+n_new]

--- a/src/Transforms.jl
+++ b/src/Transforms.jl
@@ -20,6 +20,7 @@ using Statistics: mean
 abstract type Transform end
 function apply(::Transform, x) end
 function unapply(::Transform, x) end
+function invert(::Transform) end
 
 function apply(transforms::Vector{T}, x) where T <: Transform
     return foldl((u, transform) -> apply(transform, u), transforms; init=x)
@@ -36,6 +37,7 @@ struct LinearTransform <: Transform
 end
 apply(t::LinearTransform, x) = @. t.slope * x + t.intercept
 unapply(t::LinearTransform, x) = @. (x - t.intercept) / t.slope
+invert(t::LinearTransform) = LinearTransform(1/t.slope, -t.intercept/t.slope)
 
 unapply_mean(t::LinearTransform, mean) = unapply(t, mean)
 unapply_var(t::LinearTransform, var) = @. (1/t.slope^2) * var
@@ -48,7 +50,7 @@ end
 
 """
     LinearTransform(data::Vector{<:Real}, lo, hi)
-Transform such that `minimum(data) = lo` and `maximum(data)=hi`.
+Transform such that `minimum(data) = lo` and `maximum(data) = hi`.
 """
 function LinearTransform(data::Vector{<:Real}, lo, hi)
     tnan = filter(!isnan, data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,5 +17,6 @@ using Test
 using AutoGP
 
 @testset "AutoGP" begin
-    include("test_GP.jl")
+    @testset "test_GP.jl" begin include("test_GP.jl") end
+    @testset "test_api.jl" begin include("test_api.jl") end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+# Copyright 2025 CMU Probabilistic Computing Systems Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+using Test
+using AutoGP
+
+@testset "AutoGP" begin
+    include("test_GP.jl")
+end

--- a/test/test_GP.jl
+++ b/test/test_GP.jl
@@ -19,42 +19,86 @@ using AutoGP
 using AutoGP: Transforms
 using AutoGP: GP
 
+function get_reparam_base_kernels()
+  return [
+    GP.WhiteNoise(1),
+    GP.Constant(0.5),
+    GP.Linear(0.1, 1.3, 0.7),
+    GP.SquaredExponential(0.47, 0.13),
+    GP.GammaExponential(0.42, 0.58, 3.2),
+    GP.Periodic(0.96, 0.21, 1.1),
+  ]
+end
+
 @testset "reparameterize" begin
 
     # Create raw and transformed time points.
     ds_raw = collect(range(start=-10, stop=10, length=100))
     transformation = Transforms.LinearTransform(ds_raw, 0, 1)
     ds = Transforms.apply(transformation, ds_raw)
-
-    # Kernels are assumed to be defined on the scale of ds.
-    base_kernels = [
-        GP.WhiteNoise(1),
-        GP.Constant(0.5),
-        GP.Linear(0.1, 1.3, 0.7),
-        GP.SquaredExponential(0.47, 0.13),
-        GP.GammaExponential(0.42, 0.58, 3.2),
-        GP.Periodic(0.96, 0.21, 1.1),
-    ]
+    base_kernels = get_reparam_base_kernels()
 
     # Base kernels.
     for b in base_kernels
+      @testset "base $(b)" begin
         b_raw = GP.reparameterize(b, transformation)
         M1 = GP.eval_cov(b, ds)
         M2 = GP.eval_cov(b_raw, ds_raw)
         @test all(M1 .≈ M2)
+      end
     end
 
     # Composite kernels.
     for b1 in base_kernels
-        for b2 in base_kernels
-            for op in [+, *, (x, y) -> GP.ChangePoint(x, y, 0.5, 0.95)]
-                b = op(b1, b2)
-                b_raw = GP.reparameterize(b, transformation)
-                M1 = GP.eval_cov(b, ds)
-                M2 = GP.eval_cov(b_raw, ds_raw)
-                @test all(M1 .≈ M2)
-            end
+      for b2 in base_kernels
+        for op in [+, *, (x, y) -> GP.ChangePoint(x, y, 0.5, 0.95)]
+          @testset "composite $(b1) $(b2) $(op)" begin
+              b = op(b1, b2)
+              b_raw = GP.reparameterize(b, transformation)
+              M1 = GP.eval_cov(b, ds)
+              M2 = GP.eval_cov(b_raw, ds_raw)
+              @test all(M1 .≈ M2)
+          end
         end
+      end
     end
 
-end
+end # @testset "reparameterize"
+
+@testset "rescale" begin
+
+    # Create time points.
+    ds = collect(range(start=-10, stop=10, length=50))
+
+    # Create raw and transformed y values.
+    ys_raw = collect(range(start=-10, stop=10, length=50))
+    transformation = Transforms.LinearTransform(ys_raw, -1, 1)
+    ys = Transforms.apply(transformation, ys_raw)
+    base_kernels = get_reparam_base_kernels()
+
+    # Base kernels.
+    for b in base_kernels
+      @testset "base $(b)" begin
+        b_rescale = GP.rescale(b, Transforms.invert(transformation))
+        M1 = GP.eval_cov(b_rescale, ds)
+        M2 = Transforms.unapply_var(transformation, GP.eval_cov(b, ds))
+        @test all(isapprox.(M1, M2, atol=1e-10))
+      end
+    end
+
+    # Composite kernels.
+    for b1 in base_kernels
+      for b2 in base_kernels
+        for op in [+, *, (x, y) -> GP.ChangePoint(x, y, 0.5, 0.95)]
+          @testset "composite $(b1) $(b2) $(op)" begin
+            b = op(b1, b2)
+            b_rescale = GP.rescale(b, Transforms.invert(transformation))
+            M1 = GP.eval_cov(b_rescale, ds)
+            M2 = Transforms.unapply_var(transformation, GP.eval_cov(b, ds))
+            @test all(isapprox.(M1, M2, atol=1e-8))
+          end
+        end
+      end
+    end
+
+end # @testset "rescale"

--- a/test/test_GP.jl
+++ b/test/test_GP.jl
@@ -1,0 +1,61 @@
+# Copyright 2023 Google LLC
+# Copyright 2025 CMU Probabilistic Computing Systems Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+using Revise
+using Test
+using AutoGP
+
+using AutoGP: Transforms
+using AutoGP: GP
+
+@testset "reparameterize" begin
+
+    # Create raw and transformed time points.
+    ds_raw = collect(range(start=-10, stop=10, length=100))
+    transformation = Transforms.LinearTransform(ds_raw, 0, 1)
+    ds = Transforms.apply(transformation, ds_raw)
+
+    # Kernels are assumed to be defined on the scale of ds.
+    base_kernels = [
+        GP.WhiteNoise(1),
+        GP.Constant(0.5),
+        GP.Linear(0.1, 1.3, 0.7),
+        GP.SquaredExponential(0.47, 0.13),
+        GP.GammaExponential(0.42, 0.58, 3.2),
+        GP.Periodic(0.96, 0.21, 1.1),
+    ]
+
+    # Base kernels.
+    for b in base_kernels
+        b_raw = GP.reparameterize(b, transformation)
+        M1 = GP.eval_cov(b, ds)
+        M2 = GP.eval_cov(b_raw, ds_raw)
+        @test all(M1 .≈ M2)
+    end
+
+    # Composite kernels.
+    for b1 in base_kernels
+        for b2 in base_kernels
+            for op in [+, *, (x, y) -> GP.ChangePoint(x, y, 0.5, 0.95)]
+                b = op(b1, b2)
+                b_raw = GP.reparameterize(b, transformation)
+                M1 = GP.eval_cov(b, ds)
+                M2 = GP.eval_cov(b_raw, ds_raw)
+                @test all(M1 .≈ M2)
+            end
+        end
+    end
+
+end

--- a/test/test_GP.jl
+++ b/test/test_GP.jl
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-using Revise
 using Test
 using AutoGP
 

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -1,0 +1,71 @@
+# Copyright 2023 Google LLC
+# Copyright 2025 CMU Probabilistic Computing Systems Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+using Test
+using AutoGP
+
+using AutoGP: Transforms
+using AutoGP: GP
+
+using Random: randn
+
+@testset "reparameterize" begin
+
+  # Create raw data.
+  num_train = 50
+  y_train = randn(num_train)
+  ds_train = collect(range(start=-10, stop=10, length=num_train))
+  ds_pred = collect(range(start=10, stop=15, length=num_train))
+  ds_query = vcat(ds_train, ds_pred);
+
+  # Build the model.
+  model = AutoGP.GPModel(ds_train, y_train; n_particles=4)
+
+  # Obtain transformed data.
+  ds_train_tr = AutoGP.Transforms.apply(model.ds_transform, ds_train)
+  ds_pred_tr = AutoGP.Transforms.apply(model.ds_transform, ds_pred)
+  ds_query_tr = vcat(ds_train_tr, ds_pred_tr)
+
+  # Compute y average.
+  y_train_avg = sum(y_train) / length(y_train)
+
+  # Obtain variance in the raw space.
+  noises = AutoGP.observation_noise_variances(model);
+  noises_tr = AutoGP.observation_noise_variances(model, reparameterize=false);
+
+  # Obtain kernels in raw and transformed space.
+  kernels = AutoGP.covariance_kernels(model)
+  kernels_tr = AutoGP.covariance_kernels(model; reparameterize=false);
+
+  # Confirm the covariance kernels agree.
+  for ((kr, nr), (kt,nt)) in zip(zip(kernels, noises), zip(kernels_tr, noises_tr))
+    C1 = AutoGP.GP.compute_cov_matrix_vectorized(kr, nr, ds_query)
+    C2 = Transforms.unapply_var(
+      model.y_transform,
+      AutoGP.GP.compute_cov_matrix_vectorized(kt, nt, ds_query_tr))
+    @test all(isapprox.(C1, C2, atol=1e-8))
+  end
+
+  # Obtain MVN in the transformed space.
+  mvn_tr = AutoGP.predict_mvn(model, ds_query)
+  for (i, (kr, nr)) in enumerate(zip(kernels, noises))
+    m = AutoGP.GP.Distributions.MvNormal(
+      kr, nr, ds_train, y_train, ds_query;
+      mean=t->y_train_avg)
+    @test all(isapprox.(m.μ, mvn_tr.components[i].μ))
+    @test all(isapprox.(m.Σ, mvn_tr.components[i].Σ))
+  end
+
+end


### PR DESCRIPTION
### Change 1
Adds two methods to the GP API:
- reparameterize
- rescale

These methods will take a kernel whose parameters are in the transformed space (typically [0,1] or [-1,1]) and then return an equivalent kernel over time points in the the original data space.

### Change 2
Augments the AutoGP API functions with optional arguments `reparameterize::Bool` for `observation_noise_variances` and `covariance_kernels`. Both are set to true, fixing the previous inconsistency where the former was reparameterized and the latter was not.  In brief, the kernel parameters returned by `covariance_kernels` will be interpretable with respect to the training data.

### Change 3
Adds a test suite under `tests/runtests.jl` for these functionalities and a GitHub workflow for ContinuousIntegration.yml.